### PR TITLE
Fix logging undefined response

### DIFF
--- a/src/inchPrice.ts
+++ b/src/inchPrice.ts
@@ -138,12 +138,14 @@ export async function checkArbitrage(
           .padStart(7),
 
         log:
-          e.response.status +
-          ": " +
-          e.response.statusText +
-          " (" +
-          e.response.data.error +
-          ")",
+          e.response !== undefined
+            ? e.response.status +
+              ": " +
+              e.response.statusText +
+              " (" +
+              e.response.data.error +
+              ")"
+            : "",
       },
       {
         color: "red",
@@ -185,12 +187,14 @@ export async function checkArbitrage(
           .padStart(7),
 
         log:
-          e.response.status +
-          ": " +
-          e.response.statusText +
-          " (" +
-          e.response.data.error +
-          ")",
+          e.response !== undefined
+            ? e.response.status +
+              ": " +
+              e.response.statusText +
+              " (" +
+              e.response.data.error +
+              ")"
+            : "",
       },
       {
         color: "red",


### PR DESCRIPTION
Fixed an error where every time the response was undefined it threw an error 
```
TypeError: Cannot read properties of undefined (reading 'status')
    at E:\poly-flashloan-bot-main\dist\inchPrice.js:81:33
    at Generator.next (<anonymous>)
    at fulfilled (E:\poly-flashloan-bot-main\dist\inchPrice.js:5:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```